### PR TITLE
Fixed compiler issue with missing semicolons

### DIFF
--- a/mpiomp.c
+++ b/mpiomp.c
@@ -17,7 +17,7 @@ int main(int argc, char* argv[])
 	int reducedcount;					//total number of "good" points from all nodes
 	int reducedniter;					//total number of ALL points from all nodes
 	int ranknum = 0;					//total number of nodes available
-	int numthreads = 16					//edit this number to change the number of OpenMP threads launched per MPI task
+	int numthreads = 16;					//edit this number to change the number of OpenMP threads launched per MPI task
 	MPI_Init(&argc, &argv);					//Start MPI
 	MPI_Comm_rank(MPI_COMM_WORLD, &myid);			//get rank of node's process
 	MPI_Comm_size(MPI_COMM_WORLD, &ranknum);		//Gets number of nodes availible to process

--- a/omppi.c
+++ b/omppi.c
@@ -10,7 +10,7 @@ int main(int argc, char* argv[])
         int count=0;							//Count holds all the number of how many good coordinates
 	double z;							//Used to check if x^2+y^2<=1
 	double pi;							//holds approx value of pi
-	int numthreads = 16
+	int numthreads = 16;
 
 	#pragma omp parallel firstprivate(x, y, z, i) reduction(+:count) num_threads(numthreads)
 	{


### PR DESCRIPTION
make omp and make mpiomp were failing because of missing
semicolons before pragma declarations. Addressed the issue.
